### PR TITLE
Add `meson` to dependencies and use `sassc` and `libsass` 3.5.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,8 @@ apt install git build-essential meson
 
 printf '\nDownloading, Building, and Installing SassC and LibSass:'
 cd /usr/local/lib/
-git clone https://github.com/sass/sassc.git --branch 3.2.1 --depth 1
-git clone https://github.com/sass/libsass.git --branch 3.2.1 --depth 1
+git clone https://github.com/sass/sassc.git --branch 3.5.0 --depth 1
+git clone https://github.com/sass/libsass.git --branch 3.5.0 --depth 1
 
 cd /usr/local/lib/sassc/
 export SASS_LIBSASS_PATH="/usr/local/lib/libsass"

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,8 @@
 CURRENTFOLDER=${PWD}
 
 printf '\nInstalling Dependencies:'
-apt install git build-essential
+apt update
+apt install git build-essential meson
 
 printf '\nDownloading, Building, and Installing SassC and LibSass:'
 cd /usr/local/lib/


### PR DESCRIPTION
- Add `meson` to dependencies
- Upgrade `sassc` and `libsass` dependencies from `3.2.1` to `3.5.0` to fix #1

Tested with Ubuntu Mate 17.10.1 from live